### PR TITLE
Changed output format to ome.tif

### DIFF
--- a/tools/mesmer/mesmer.xml
+++ b/tools/mesmer/mesmer.xml
@@ -48,7 +48,7 @@
         </conditional>
     </inputs>
     <outputs>
-        <data format="tiff" name="mask" from_work_dir="mask.tif" label="${tool.name} on ${on_string}: Mask"/>
+        <data format="ome.tiff" name="mask" from_work_dir="mask.ome.tif" label="${tool.name} on ${on_string}: Mask"/>
     </outputs>
     <tests>
         <test>
@@ -57,7 +57,7 @@
             <param name="membrane_select.membrane_segment" value="False" />
             <param name="image_mmp" value="0.65" />
             <param name="squeeze" value="--squeeze" />
-            <output name="mask" ftype="tiff">
+            <output name="mask" ftype="ome.tiff">
                 <assert_contents>
                     <has_size value="360000" delta="1000" />
                 </assert_contents>


### PR DESCRIPTION
Current output format (.tiff) was not compatible with proper visualization in Napari. Changing to .ome.tiff solved the issue when done manually and so having .ome.tiff as default output should hopefully resolve this issue for other users.