### PR TITLE
Handle zero values in autofluorescence signal processing

### DIFF
--- a/tools/mti-utils/macros.xml
+++ b/tools/mti-utils/macros.xml
@@ -14,8 +14,8 @@
         <citation type="doi">10.1101/2022.08.18.504436</citation>
         </citations>
     </xml>
-
+    
     <token name="@TOOL_VERSION@">0.0.1</token>
-    <token name="@VERSION_SUFFIX@">3</token>
+    <token name="@VERSION_SUFFIX@">4</token>
     <token name="@PROFILE@">19.01</token>
 </macros>

--- a/tools/mti-utils/process_intensities.xml
+++ b/tools/mti-utils/process_intensities.xml
@@ -30,12 +30,12 @@ markers_to_normalize = marker_df['marker_name'].to_list()
 AF_markers = [x for x in list(marker_df['${AF_method.AF_col}'].unique()) if x != 'None']
 print(f'Detected {quant[AF_markers].eq(0.0).any(axis=1).sum()} cells with AF values of zero in the dataset')
 
-#if $filter.AF_filter == 'filter':
+#if $AF_filter == 'filter':
 pre_filter_count = len(quant)
 quant = quant.loc[quant[AF_markers].ne(0.0).any(axis=1),:]
 print(f'Filtered out {pre_filter_count - len(quant)} cells that had AF values of 0.0')
 
-#elif $filter.AF_filter == 'clip':
+#elif $AF_filter == 'clip':
 print('Clipping all AF values equal to 0.0 to the minimum non-zero AF value')
 for af in AF_markers:
     quant[af] = quant[af].clip(lower = quant[af][quant[af].ne(0.0)].min())
@@ -91,14 +91,10 @@ quant.to_csv(os.path.join(cwd, 'processed_quant.csv'))
             </when>
             <when value="SBR">
                 <param name="AF_col" type="text" value="AF_channel" label="Name of column in markers file containing respective AF channel for each marker" />
-                <conditional name="filter">
-                    <param name="AF_filter" type="select" label="Select whether to clip or filter out AF values equal to 0">
-                        <option value="clip">Clip autofluorescence values of 0.0 to the minimum non-zero autofluorescence value</option>
-                        <option value="filter">Filter out cells with autofluorescence values equal to 0.0</option>
-                    </param>
-                    <when value="clip" />
-                    <when value="filter" />
-                </conditional>
+                <param name="AF_filter" type="select" label="Select whether to clip or filter out AF values equal to 0">
+                    <option value="clip">Clip autofluorescence values of 0.0 to the minimum non-zero autofluorescence value</option>
+                    <option value="filter">Filter out cells with autofluorescence values equal to 0.0</option>
+                </param>
             </when>
         </conditional>
     </inputs>
@@ -114,9 +110,7 @@ quant.to_csv(os.path.join(cwd, 'processed_quant.csv'))
             </conditional>
             <conditional name="AF_method">
                 <param name="select_method" value="SBR" />
-                <conditional name="filter">
                     <param name="AF_filter" value="clip" />
-                </conditional>
             </conditional>
             <output name="processed_quant" ftype="csv">
                 <assert_contents>

--- a/tools/mti-utils/process_intensities.xml
+++ b/tools/mti-utils/process_intensities.xml
@@ -26,6 +26,23 @@ marker_df = pd.read_csv('$channel_csv')
 
 markers_to_normalize = marker_df['marker_name'].to_list()
 
+#if $AF_method.select_method == 'SBR':
+AF_markers = [x for x in list(marker_df['${AF_method.AF_col}'].unique()) if x != 'None']
+print(f'Detected {quant[AF_markers].eq(0.0).any(axis=1).sum()} cells with AF values of zero in the dataset')
+
+#if $filter.AF_filter == 'filter':
+pre_filter_count = len(quant)
+quant = quant.loc[quant[AF_markers].ne(0.0).any(axis=1),:]
+print(f'Filtered out {pre_filter_count - len(quant)} cells that had AF values of 0.0')
+
+#elif $filter.AF_filter == 'clip':
+print('Clipping all AF values equal to 0.0 to the minimum non-zero AF value')
+for af in AF_markers:
+    quant[af] = quant[af].clip(lower = quant[af][quant[af].ne(0.0)].min())
+
+#end if
+#end if
+
 for marker in markers_to_normalize:
 
 #if $exp.exposure == 'correct_exposure':
@@ -74,6 +91,14 @@ quant.to_csv(os.path.join(cwd, 'processed_quant.csv'))
             </when>
             <when value="SBR">
                 <param name="AF_col" type="text" value="AF_channel" label="Name of column in markers file containing respective AF channel for each marker" />
+                <conditional name="filter">
+                    <param name="AF_filter" type="select" label="Select whether to clip or filter out AF values equal to 0">
+                        <option value="clip">Clip autofluorescence values of 0.0 to the minimum non-zero autofluorescence value</option>
+                        <option value="filter">Filter out cells with autofluorescence values equal to 0.0</option>
+                    </param>
+                    <when value="clip" />
+                    <when value="filter" />
+                </conditional>
             </when>
         </conditional>
     </inputs>
@@ -89,6 +114,9 @@ quant.to_csv(os.path.join(cwd, 'processed_quant.csv'))
             </conditional>
             <conditional name="AF_method">
                 <param name="select_method" value="SBR" />
+                <conditional name="filter">
+                    <param name="AF_filter" value="clip" />
+                </conditional>
             </conditional>
             <output name="processed_quant" ftype="csv">
                 <assert_contents>


### PR DESCRIPTION
Adds two options to SBR calculation for dealing with zero values, which were previously causing Inf and NaNs in output. Users can either filter out zero-valued AF cells, or clip the zero values to the minimum non-zero value in the respective AF channel 