### PR TITLE
disabling progress bars, removing numba_parallel

### DIFF
--- a/tools/squidpy/main_macros.xml
+++ b/tools/squidpy/main_macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <token name="@TOOL_VERSION@">1.4.1</token>
     <token name="@PROFILE@">20.01</token>
-    <token name="@VERSION_SUFFIX@">0</token> 
+    <token name="@VERSION_SUFFIX@">1</token> 
 
     <xml name="macro_stdio">
         <stdio>

--- a/tools/squidpy/squidpy_spatial.py
+++ b/tools/squidpy/squidpy_spatial.py
@@ -38,15 +38,6 @@ def main(inputs, anndata, output, output_plot):
     tool_func = getattr(sq.gr, tool)
 
     options = params['analyses']['options']
-    progress_bar_tools = [
-        'centrality_scores',
-        'co_occurrence',
-        'nhood_enrichment',
-        'sepal',
-        'spatial_autocorr'
-    ]
-    if tool in progress_bar_tools:
-        options['show_progress_bar'] = False
 
     for k, v in options.items():
         if not isinstance(v, str):

--- a/tools/squidpy/squidpy_spatial.py
+++ b/tools/squidpy/squidpy_spatial.py
@@ -38,6 +38,15 @@ def main(inputs, anndata, output, output_plot):
     tool_func = getattr(sq.gr, tool)
 
     options = params['analyses']['options']
+    progress_bar_tools = [
+        'centrality_scores',
+        'co_occurrence',
+        'nhood_enrichment',
+        'sepal',
+        'spatial_autocorr'
+        ]
+    if tool in progress_bar_tools:
+        options['show_progress_bar']=False
 
     for k, v in options.items():
         if not isinstance(v, str):
@@ -51,11 +60,6 @@ def main(inputs, anndata, output, output_plot):
             options[k] = [e.strip() for e in v.split(',')]
         elif k == 'radius':    # for spatial_neighbors
             options[k] = ast.literal_eval(v)
-        elif k == 'numba_parallel':    # for nhood_enrichment and ligrec
-            if v == 'false':
-                options[k] = False
-            elif v == 'true':
-                options[k] = True
         elif k == 'interactions':    # for ligrec
             options[k] = pd.read_csv(v, sep="\t")
         elif k == 'max_neighs':

--- a/tools/squidpy/squidpy_spatial.py
+++ b/tools/squidpy/squidpy_spatial.py
@@ -44,9 +44,9 @@ def main(inputs, anndata, output, output_plot):
         'nhood_enrichment',
         'sepal',
         'spatial_autocorr'
-        ]
+    ]
     if tool in progress_bar_tools:
-        options['show_progress_bar']=False
+        options['show_progress_bar'] = False
 
     for k, v in options.items():
         if not isinstance(v, str):

--- a/tools/squidpy/squidpy_spatial.xml
+++ b/tools/squidpy/squidpy_spatial.xml
@@ -11,6 +11,7 @@
     <version_command>echo "@TOOL_VERSION@"</version_command>
     <command detect_errors="aggressive">
         <![CDATA[
+        export TQDM_DISABLE=True &&
         python '$__tool_directory__/squidpy_spatial.py'
             --inputs '$inputs'
             --anndata '$anndata'

--- a/tools/squidpy/squidpy_spatial.xml
+++ b/tools/squidpy/squidpy_spatial.xml
@@ -64,11 +64,6 @@
                 <expand macro="squidpy_spatial_options">
                     <param argument="connectivity_key" type="text" value="" optional="true" label="Key in anndata.AnnData.obsp where spatial connectivities are stored" />
                     <param argument="n_perms" type="integer" value="1000" label="Number of permutations for the permutation test" />
-                    <param argument="numba_parallel" type="select" label="Whether to use numba.prange or not">
-                        <option value="false" selected="true">No -- Recommended for small datasets or small number of interactions</option>
-                        <option value="true">Yes</option>
-                        <option value="none">Auto</option>
-                    </param>
                     <param argument="seed" type="integer" value="" optional="true" label="Randomness seed" />
                 </expand>
                 <expand macro="squidpy_plotting_options_more">
@@ -180,11 +175,6 @@
                     <param argument="corr_axis" type="select" label="Axis over which to perform the FDR correction" help="Only used when corr_method != None.">
                         <option value="clusters" selected="true">clusters -- correct clusters by performing FDR correction across the interactions</option>
                         <option value="interactions">interactions -- correct interactions by performing FDR correction across the clusters</option>
-                    </param>
-                    <param argument="numba_parallel" type="select" label="Whether to use numba.prange or not">
-                        <option value="false" selected="true">No -- Recommended for small datasets or small number of interactions</option>
-                        <option value="true">Yes</option>
-                        <option value="none">Auto</option>
                     </param>
                     <param argument="key_added" type="text" value="" optional="true" label="Key in anndata to store the result" help="In `anndata.AnnData.uns`. If None, '{cluster_key}_ligrec' will be used." />
                     <param argument="gene_symbols" type="text" value="" optional="true" label="Key in anndata.AnnData.var to use instead of anndata.AnnData.var_names" help="Optional." />


### PR DESCRIPTION
two main changes:

Disabling progress bars:

This was causing OSErrors when interacting with the filesystem; the fs couldn't remove a 'silly rename' NFS file (a deletion artifact of the form `.nfsxxxxxxxxxxx`), which it turns out was because of the writes to the stderr file that the progress bar was causing. the progress bar is useless as a tool output, so its removal is good for all tool users.


Removing `numba_parallel` param:
There were two issues with this; when set to `true`, runtimes became vastly longer (hours instead of minutes). When set to `auto` nothing would happen, because, while [the docs state that setting the param to `None` makes it automatically set a value](https://squidpy.readthedocs.io/en/stable/api/squidpy.gr.nhood_enrichment.html), that [does not appear to be the case](https://github.com/scverse/squidpy/blob/5d5e73ad165f858e006e98499481add175a8c8ca/src/squidpy/gr/_nhood.py#L185) (if the parameter is omitted, the default becomes `false`, though thats not especially 'automatic' a choice). So, leaving the default of `false` seems like a better choice