### PR TITLE
Vitessce container update

### DIFF
--- a/tools/vitessce/dependencies/Dockerfile
+++ b/tools/vitessce/dependencies/Dockerfile
@@ -1,7 +1,6 @@
-FROM ubuntu:jammy
+FROM ubuntu:20.04
 
-
-ARG python_version='3.10.*'
+ARG python_version='3.10'
 ARG vitessce_version='1.0.4'
 ARG anndata_version='0.8.*'
 ARG numpy_version='1.23.0'
@@ -11,12 +10,17 @@ RUN apt update && \
     ln -snf /usr/share/zoneinfo/$CONTAINER_TIMEZONE /etc/localtime && echo $CONTAINER_TIMEZONE > /etc/timezone && \
     apt install -y \
         --no-install-recommends \
+        software-properties-common && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt update && \
+    apt install -y \
+        --no-install-recommends \
         curl \
         git \
         openjdk-8-jdk \
         unzip \
         wget \
-        python3=$python_version \
+        python$python_version \
         python3-pip && \
     rm -rf /var/lib/apt/lists/* && \
     ln -s /usr/bin/python3 /usr/bin/python

--- a/tools/vitessce/main_macros.xml
+++ b/tools/vitessce/main_macros.xml
@@ -5,7 +5,7 @@
 
     <xml name="vitessce_requirements">
         <requirements>
-            <container type="docker">quay.io/goeckslab/vitessce:@TOOL_VERSION@v2</container>
+            <container type="docker">quay.io/goeckslab/vitessce:@TOOL_VERSION@v3</container>
         </requirements>
     </xml>
 

--- a/tools/vitessce/main_macros.xml
+++ b/tools/vitessce/main_macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">1.0.4</token>
-    <token name="@VERSION_SUFFIX@">4</token>
+    <token name="@VERSION_SUFFIX@">5</token>
     <token name="@PROFILE@">20.01</token>
 
     <xml name="vitessce_requirements">


### PR DESCRIPTION
When running on our local infra that has a wildly out-of-date docker engine (version `1.13.1`) that the powers that be have no intention of updating, environment sensing fails to distinguish between the host and container memory, and all java operations crash with memory errors -- presumably trying to allocate more than their allotment.

After much trial and error, it seems like simply downgrading from ubuntu 'jammy' (22.04) to 'focal' (20.04) fixes this, so the container has been modified accordingly. 

note:
- this involves adding python 3.10 via the deadsnakes repository, as 20.04 doesn't have native support for it