### PR TITLE
Expose scimap spatial LDA outputs to Galaxy user 

### DIFF
--- a/tools/scimap/main_macros.xml
+++ b/tools/scimap/main_macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.1.0</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">20.01</token>
 
     <xml name="scimap_requirements">

--- a/tools/scimap/scimap_spatial.py
+++ b/tools/scimap/scimap_spatial.py
@@ -3,6 +3,7 @@ import json
 import warnings
 
 import scimap as sm
+import pandas as pd
 from anndata import read_h5ad
 
 
@@ -28,6 +29,8 @@ def main(inputs, anndata, output):
     tool_func = getattr(sm.tl, tool)
 
     options = params['analyses']['options']
+
+    # tool specific pre-processing
     if tool == 'cluster':
         options['method'] = params['analyses']['method']
         subset_genes = options.pop('subset_genes')
@@ -38,15 +41,42 @@ def main(inputs, anndata, output):
         if sub_cluster_group:
             options['sub_cluster_group'] = \
                 [x.strip() for x in sub_cluster_group.split(',')]
+    elif tool == 'spatial_lda':
+        max_weight_assignment = options.pop('max_weight_assignment')
 
     for k, v in options.items():
         if v == '':
             options[k] = None
 
+    # tool execution
     tool_func(adata, **options)
 
+    # spatial LDA post-processing
     if tool == 'spatial_lda':
-        adata.uns.pop('spatial_lda_model')
+
+        if max_weight_assignment:
+            # assign cell to a motif based on maximum weight
+            adata.uns['spatial_lda']['neighborhood_motif'] = \
+                adata.uns['spatial_lda'].idxmax(axis=1)
+
+            # merge motif assignment into adata.obs
+            adata.obs = pd.merge(
+                adata.obs,
+                adata.uns['spatial_lda']['neighborhood_motif'],
+                left_index=True,
+                right_index=True
+            )
+
+        # write out LDA results as tabular files
+        # so they're accessible to Galaxy users
+        adata.uns['spatial_lda'].reset_index().to_csv(
+            'lda_weights.txt', sep='\t', index=False)
+        adata.uns['spatial_lda_probability'].T.reset_index(
+            names='motif').to_csv(
+                'lda_probabilities.txt', sep='\t', index=False)
+
+        if 'spatial_lda_model' in adata.uns:
+            adata.uns.pop('spatial_lda_model')
 
     adata.write(output)
 

--- a/tools/scimap/scimap_spatial.py
+++ b/tools/scimap/scimap_spatial.py
@@ -2,8 +2,8 @@ import argparse
 import json
 import warnings
 
-import scimap as sm
 import pandas as pd
+import scimap as sm
 from anndata import read_h5ad
 
 

--- a/tools/scimap/scimap_spatial.xml
+++ b/tools/scimap/scimap_spatial.xml
@@ -144,6 +144,7 @@
                     <param argument="knn" type="integer" value="10" optional="true" label="Number of cells considered for defining the local neighbhourhood" />
                     <param argument="num_motifs" type="integer" value="10" optional="true" label="The number of requested latent motifs to be extracted from the training corpus" />
                     <param argument="random_state" type="integer" value="0" optional="true" label="The seed number for random state" />
+                    <param argument="max_weight_assignment" type="boolean" checked="false" optional="true" label="Assign cells to motifs based on maximum LDA weight" />
                 </expand>
             </when>
             <when value="spatial_pscore">
@@ -163,6 +164,11 @@
     </inputs>
     <outputs>
         <data format="h5ad" name="output" label="Scimap.tools.${analyses.selected_tool} on ${on_string}" />
+        <collection name="tabular_outputs" type="list" label="Tabular outputs from Scimap.tools.${analyses.selected_tool} on ${on_string}">
+            <data format="txt" name="lda_weights" from_work_dir="lda_weights.txt" label="LDA weights from Scimap.tools.${analyses.selected_tool} on ${on_string}" />
+            <data format="txt" name="lda_probabilities" from_work_dir="lda_probabilities.txt" label="LDA probabilites from Scimap.tools.${analyses.selected_tool} on ${on_string}" />
+            <filter>analyses['selected_tool'] == 'spatial_lda'</filter>
+        </collection>
     </outputs>
     <tests>
         <test>

--- a/tools/scimap/scimap_spatial.xml
+++ b/tools/scimap/scimap_spatial.xml
@@ -171,7 +171,7 @@
         </collection>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="1">
             <param name="anndata" value="tutorial_data_pheno.h5ad" />
             <conditional name="analyses">
                 <param name="selected_tool" value="cluster" />
@@ -183,7 +183,7 @@
                 </assert_contents>
             </output>
         </test>
-        <test>
+        <test expect_num_outputs="1">
             <param name="anndata" value="tutorial_data_pheno.h5ad" />
             <conditional name="analyses">
                 <param name="selected_tool" value="spatial_aggregate" />
@@ -193,6 +193,34 @@
                     <has_h5_keys keys="obs/spatial_aggregate" />
                 </assert_contents>
             </output>
+        </test>
+        <test expect_num_outputs="4">
+            <param name="anndata" value="tutorial_data_pheno.h5ad" />
+            <conditional name="analyses">
+                <param name="selected_tool" value="spatial_lda" />
+                <section name="options">
+                    <param name="max_weight_assignment" value="True" />
+                </section>
+            </conditional>
+            <output name="output">
+                <assert_contents>
+                    <has_h5_keys keys="obs/neighborhood_motif" />
+                </assert_contents>
+            </output>
+            <output_collection name="tabular_outputs" type="list">
+                <element name="lda_weights">
+                    <assert_contents>
+                        <has_n_lines n="500" />
+                        <has_n_columns n="12" />
+                    </assert_contents>
+                </element>
+                <element name="lda_probabilities">
+                    <assert_contents>
+                        <has_n_lines n="11" />
+                        <has_n_columns n="15" />
+                    </assert_contents>
+                </element>
+            </output_collection>
         </test>
     </tests>
     <help>

--- a/tools/scimap/scimap_spatial.xml
+++ b/tools/scimap/scimap_spatial.xml
@@ -165,8 +165,8 @@
     <outputs>
         <data format="h5ad" name="output" label="Scimap.tools.${analyses.selected_tool} on ${on_string}" />
         <collection name="tabular_outputs" type="list" label="Tabular outputs from Scimap.tools.${analyses.selected_tool} on ${on_string}">
-            <data format="txt" name="lda_weights" from_work_dir="lda_weights.txt" label="LDA weights from Scimap.tools.${analyses.selected_tool} on ${on_string}" />
-            <data format="txt" name="lda_probabilities" from_work_dir="lda_probabilities.txt" label="LDA probabilites from Scimap.tools.${analyses.selected_tool} on ${on_string}" />
+            <data format="tabular" name="lda_weights" from_work_dir="lda_weights.txt" label="LDA weights from Scimap.tools.${analyses.selected_tool} on ${on_string}" />
+            <data format="tabular" name="lda_probabilities" from_work_dir="lda_probabilities.txt" label="LDA probabilites from Scimap.tools.${analyses.selected_tool} on ${on_string}" />
             <filter>analyses['selected_tool'] == 'spatial_lda'</filter>
         </collection>
     </outputs>


### PR DESCRIPTION
The current implementation of `scimap.tl.spatial_lda` saves outputs to the unstructured metadata of anndata h5ad file (`adata.uns`). We don't yet have good ways in Galaxy to access or manipulate `adata.uns`, so this PR does the following: 

- Takes the primary outputs of `spatial_lda` (cell x motif weights matrix, cell-type x motif weights matrix) and saves them as tabular files alongside the output h5ad file 
- Adds an option to the Galaxy tool (`max_weight_assignment`) which assigns cells to the neighborhood motif with the heighest weight in the cell x motif weights matrix. Motif assignments get stored in the tabular output file, and in `adata.obs/neighborhood_motif`