### PR TITLE
Expose colormap param for Galaxy scimap stacked_barplot wrapper

### DIFF
--- a/tools/scimap/main_macros.xml
+++ b/tools/scimap/main_macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.1.0</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <token name="@PROFILE@">20.01</token>
 
     <xml name="scimap_requirements">

--- a/tools/scimap/scimap_plotting.py
+++ b/tools/scimap/scimap_plotting.py
@@ -3,7 +3,8 @@ import json
 import os
 import warnings
 
-import matplotlib.pylab as plt
+import matplotlib.pyplot as plt
+from matplotlib import colormaps
 import numpy as np
 import scimap as sm
 import seaborn as sns
@@ -37,9 +38,11 @@ def main(inputs, anndata, output):
 
         # parse list text arguments
         for o in options.copy():
-            opt_list = options.pop(o)
-            if opt_list:
-                options[o] = [x.strip() for x in opt_list.split(',')]
+            opt = options.pop(o)
+            if o == 'matplotlib_cmap':
+                matplotlib_cmap = opt
+            elif opt != "":
+                options[o] = [x.strip() for x in opt.split(',')]
 
         # add base args into options dict to pass to tool
         options['x_axis'] = params['analyses']['x_axis']
@@ -51,13 +54,18 @@ def main(inputs, anndata, output):
         df = sm.pl.stacked_barplot(adata, **options)
 
         # Pick cmap to use
-        num_phenotypes = len(df.columns) - 1
-        if num_phenotypes <= 9:
-            matplotlib_cmap = "Set1"
-        elif num_phenotypes > 9 and num_phenotypes <= 20:
-            matplotlib_cmap = plt.cm.tab20
-        else:
-            matplotlib_cmap = plt.cm.gist_ncar
+        if matplotlib_cmap not in list(colormaps):
+            print('Using default color options')
+            print('For different y-axis category colors,')
+            print('enter one of the following strings for the colormap param:')
+            print(list(colormaps))
+            num_phenotypes = len(df.columns) - 1
+            if num_phenotypes <= 9:
+                matplotlib_cmap = "Set1"
+            elif num_phenotypes > 9 and num_phenotypes <= 20:
+                matplotlib_cmap = plt.cm.tab20
+            else:
+                matplotlib_cmap = plt.cm.gist_ncar
 
         # Plotting
         sns.set_theme(style="white")

--- a/tools/scimap/scimap_plotting.py
+++ b/tools/scimap/scimap_plotting.py
@@ -8,7 +8,6 @@ import numpy as np
 import scimap as sm
 import seaborn as sns
 from anndata import read_h5ad
-from matplotlib import colormaps
 
 sns.set(color_codes=True)
 
@@ -52,20 +51,6 @@ def main(inputs, anndata, output):
         options['return_data'] = True
 
         df = sm.pl.stacked_barplot(adata, **options)
-
-        # Pick cmap to use
-        if matplotlib_cmap not in list(colormaps):
-            print('Using default color options')
-            print('For different y-axis category colors,')
-            print('enter one of the following strings for the colormap param:')
-            print(list(colormaps))
-            num_phenotypes = len(df.columns) - 1
-            if num_phenotypes <= 9:
-                matplotlib_cmap = "Set1"
-            elif num_phenotypes > 9 and num_phenotypes <= 20:
-                matplotlib_cmap = plt.cm.tab20
-            else:
-                matplotlib_cmap = plt.cm.gist_ncar
 
         # Plotting
         sns.set_theme(style="white")

--- a/tools/scimap/scimap_plotting.py
+++ b/tools/scimap/scimap_plotting.py
@@ -4,10 +4,10 @@ import os
 import warnings
 
 import matplotlib.pyplot as plt
-from matplotlib import colormaps
 import numpy as np
 import scimap as sm
 import seaborn as sns
+from matplotlib import colormaps
 from anndata import read_h5ad
 
 sns.set(color_codes=True)

--- a/tools/scimap/scimap_plotting.py
+++ b/tools/scimap/scimap_plotting.py
@@ -7,8 +7,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import scimap as sm
 import seaborn as sns
-from matplotlib import colormaps
 from anndata import read_h5ad
+from matplotlib import colormaps
 
 sns.set(color_codes=True)
 

--- a/tools/scimap/scimap_plotting.xml
+++ b/tools/scimap/scimap_plotting.xml
@@ -38,6 +38,7 @@
                     <param argument="subset_yaxis" type="text" value="" optional="true" label="Subset y-axis prior to plotting. Type in a list of categories to include on y-axis" help="Optional. Comma delimited. Default is all categories in y-axis variable" />
                     <param argument="order_xaxis" type="text" value="" optional="true" label="Type in a list of categories to order to x-axis" help="Optional. Comma delimited. Default ordering is alphabetical" />
                     <param argument="order_yaxis" type="text" value="" optional="true" label="Type in a list of categories to order to y-axis" help="Optional. Comma delimited. Default ordering is alphabetical" />
+                    <param argument="matplotlib_cmap" type="text" value="" optional="true" label="Matplotlib colormap to use for y-axis categories" help="Optional. If not specified, cmap is determined based on number of categories" />
                 </section>
             </when>
             <when value="voronoi">

--- a/tools/scimap/scimap_plotting.xml
+++ b/tools/scimap/scimap_plotting.xml
@@ -38,7 +38,20 @@
                     <param argument="subset_yaxis" type="text" value="" optional="true" label="Subset y-axis prior to plotting. Type in a list of categories to include on y-axis" help="Optional. Comma delimited. Default is all categories in y-axis variable" />
                     <param argument="order_xaxis" type="text" value="" optional="true" label="Type in a list of categories to order to x-axis" help="Optional. Comma delimited. Default ordering is alphabetical" />
                     <param argument="order_yaxis" type="text" value="" optional="true" label="Type in a list of categories to order to y-axis" help="Optional. Comma delimited. Default ordering is alphabetical" />
-                    <param argument="matplotlib_cmap" type="text" value="" optional="true" label="Matplotlib colormap to use for y-axis categories" help="Optional. See link below for colormap options" />
+                    <param argument="matplotlib_cmap" type="select" label="Matplotlib colormap to use for y-axis categories" help="See link below for colormaps explanation">
+                        <option value="Pastel1">Pastel1</option>
+                        <option value="Pastel2">Pastel2</option>
+                        <option value="Paired">Paired</option>
+                        <option value="Accent">Accent</option>
+                        <option value="Dark2">Dark2</option>
+                        <option selected="true" value="Set1">Set1</option>
+                        <option value="Set2">Set2</option>
+                        <option value="Set3">Set3</option>
+                        <option value="tab10">tab10</option>
+                        <option value="tab20">tab20</option>
+                        <option value="tab20b">tab20b</option>
+                        <option value="tab20c">tab20c</option>
+                    </param>
                 </section>
             </when>
             <when value="voronoi">
@@ -100,9 +113,7 @@
 
 This tool creates stacked barplots or Voronoi plots from single-cell spatial data using Scimap
 
-For the stacked barplot tool, find colormap options here: https://matplotlib.org/stable/users/explain/colors/colormaps.html
-
-Example colormaps would be 'Set1', 'Set3', 'tab10', etc.
+For the stacked barplot tool, find colormap descriptions here: https://matplotlib.org/stable/users/explain/colors/colormaps.html
 
         ]]>
     </help>

--- a/tools/scimap/scimap_plotting.xml
+++ b/tools/scimap/scimap_plotting.xml
@@ -38,7 +38,7 @@
                     <param argument="subset_yaxis" type="text" value="" optional="true" label="Subset y-axis prior to plotting. Type in a list of categories to include on y-axis" help="Optional. Comma delimited. Default is all categories in y-axis variable" />
                     <param argument="order_xaxis" type="text" value="" optional="true" label="Type in a list of categories to order to x-axis" help="Optional. Comma delimited. Default ordering is alphabetical" />
                     <param argument="order_yaxis" type="text" value="" optional="true" label="Type in a list of categories to order to y-axis" help="Optional. Comma delimited. Default ordering is alphabetical" />
-                    <param argument="matplotlib_cmap" type="text" value="" optional="true" label="Matplotlib colormap to use for y-axis categories" help="Optional. If not specified, cmap is determined based on number of categories" />
+                    <param argument="matplotlib_cmap" type="text" value="" optional="true" label="Matplotlib colormap to use for y-axis categories" help="Optional. See link below for colormap options" />
                 </section>
             </when>
             <when value="voronoi">
@@ -98,16 +98,11 @@
         <![CDATA[
 **What it does**
 
-This tool does various single cell spatial analyses with Scimap.
+This tool creates stacked barplots or Voronoi plots from single-cell spatial data using Scimap
 
-**Input**
+For the stacked barplot tool, find colormap options here: https://matplotlib.org/stable/users/explain/colors/colormaps.html
 
-AnnData.
-
-**Output**
-
-Anndata with a corresponding key added.
-
+Example colormaps would be 'Set1', 'Set3', 'tab10', etc.
 
         ]]>
     </help>


### PR DESCRIPTION
### Currently, the scimap stacked barplot galaxy tool uses only default colormaps for y-axis categories. This can lead to poor color discrimination between categories depending on the number of categories being plotted. To fix this, this PR adds a colormap param so users can pick their colors more flexibly. 

---

**This PR is related to**
- [ ] Adding a new tool 
- [ ] Updating an existing tool to a newer version
- [x] Fixing a bug or updating just the Galaxy wrapper of an existing tool
- [ ] Making a change to the `tools-mti` repo, CI, or other misc. change

---

**If updating an existing tool to a newer major version**
- [ ] I have updated the `TOOL_VERSION` token in the tool's macros file 
- [ ] I have reset the `VERSION_SUFFIX` to `0` in the tool's macros file 

---

### Provide details here

- Incremented `VERSION_SUFFIX` to `2`