### PR TITLE
Fix to Squidpy Scatter input config parsing

### DIFF
--- a/tools/squidpy/main_macros.xml
+++ b/tools/squidpy/main_macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <token name="@TOOL_VERSION@">1.5.0</token>
     <token name="@PROFILE@">20.01</token>
-    <token name="@VERSION_SUFFIX@">1</token> 
+    <token name="@VERSION_SUFFIX@">2</token> 
 
     <xml name="macro_stdio">
         <stdio>

--- a/tools/squidpy/squidpy_scatter.py
+++ b/tools/squidpy/squidpy_scatter.py
@@ -22,10 +22,16 @@ def main(inputs, output_plot):
         params = json.load(param_handler)
 
     # collapse param dict hierarchy, parse inputs
+    main_params = ['anndata', 'x_coord', 'y_coord', 'color']
     plot_opts = params.pop('plot_opts')
     legend_opts = params.pop('legend_opts')
     aes_opts = params.pop('aesthetic_opts')
-    options = {**params, **plot_opts, **legend_opts, **aes_opts}
+    options = {
+        **{k: params[k] for k in main_params},
+        **plot_opts,
+        **legend_opts,
+        **aes_opts
+    }
 
     # read input anndata file
     adata_fh = options.pop('anndata')


### PR DESCRIPTION
We recently implemented user-selectable job resources at runtime on some of our instances, which adds a key to the input config file (`"__job_resource": {"__job_resource__select": "no"}`). This was causing errors for the Squidpy spatial scatterplot tool, as it tried to parse all params in the input config. Added a line to be more explicit about which params to parse in the python script 

---

**This PR is related to**
- [ ] Adding a new tool 
- [ ] Updating an existing tool to a newer version
- [x] Fixing a bug or updating just the Galaxy wrapper of an existing tool
- [ ] Making a change to the `tools-mti` repo, CI, or other misc. change