### PR TITLE
Add channel naming back into ashlar wrapper

### DIFF
--- a/tools/ashlar/ashlar.xml
+++ b/tools/ashlar/ashlar.xml
@@ -1,4 +1,4 @@
-<tool id="ashlar" name="ASHLAR" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="19.01">
+<tool id="ashlar" name="ASHLAR" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="22.01">
     <description>Alignment by Simultaneous Harmonization of Layer/Adjacency Registration</description>
     <macros>
         <import>macros.xml</import>
@@ -81,6 +81,12 @@
         $adv.flip_mosaic_y
 
         -o registered.ome.tif;
+
+        #if $rename.decide == "do_rename"
+            python3 '${__tool_directory__}/rename_channels.py'
+            --image registered.ome.tif
+            --markers '$rename.markers_file';
+        #end if
     ]]></command>
 
     <inputs>
@@ -90,6 +96,17 @@
         <param name="flip_x" type="boolean" truevalue="--flip-x" falsevalue="" label="Flip X-axis"/>
         <param name="flip_y" type="boolean" truevalue="--flip-y" falsevalue="" label="Flip Y-axis"/>
         <param name="max_shift" type="integer" value="30" label="Maximum allowed per-tile corrective shift" help="In micros"/>
+        <conditional name="rename">
+            <param name="decide" type="select" label="Rename channels in OME-XML metadata">
+                <option value="do_rename">Rename channels</option>
+                <option value="dont_rename" selected="true">Leave channel indices</option>
+            </param>
+            <when value="do_rename">
+                <param name="markers_file" type="data" format="csv" label="Markers File"/>
+            </when>
+            <when value="dont_rename">
+            </when>
+        </conditional>
         <section name="adv" title="Advanced Options" expanded="false">
             <param name="align_channel" type="integer" value="0" label="Align Channel Number"/>
             <param name="stitch_alpha" type="float" optional="true" label="Alpha"/>
@@ -116,6 +133,28 @@
                     <has_size value="500000" delta="400000" />
                 </assert_contents>
             </output>
+        </test>
+        <test>
+            <param name="lraw">
+                <collection type="list">
+                    <element name="rR1" value="ashlar_test_c0.tiff" />
+                    <element name="rR2" value="ashlar_test_c1.tiff" />
+                </collection>
+            </param>
+            <conditional name="rename">
+                <param name="decide" value="do_rename" />
+                <param name="markers_file" value="ashlar_test_markers.csv" />
+            </conditional>
+            <output name="output" ftype="ome.tiff">
+                <assert_contents>
+                    <has_size value="500000" delta="400000" />
+                </assert_contents>
+            </output>
+            <assert_stdout>
+                <has_text text="DAPI" />
+                <has_text text="CD3" />
+                <has_text text="µm" />
+            </assert_stdout>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/ashlar/macros.xml
+++ b/tools/ashlar/macros.xml
@@ -17,6 +17,6 @@
     </xml>
 
     <token name="@TOOL_VERSION@">1.18.0</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@CMD_BEGIN@">ashlar</token>
 </macros>

--- a/tools/ashlar/rename_channels.py
+++ b/tools/ashlar/rename_channels.py
@@ -1,0 +1,81 @@
+# ------------------------------------------------------------------------------------
+# Stripped down and modified from:
+# https://github.com/ohsu-comp-bio/ashlar/blob/master/pyramid_upgrade.py
+# ------------------------------------------------------------------------------------
+
+import os
+import sys 
+import argparse
+import csv
+import xml.etree.ElementTree
+from tifffile import tiffcomment
+
+
+def fix_attrib_namespace(elt):
+    """Prefix un-namespaced XML attributes with the tag's namespace."""
+    # This fixes ElementTree's inability to round-trip XML with a default
+    # namespace ("cannot use non-qualified names with default_namespace option"
+    # error). 7-year-old BPO issue here: https://bugs.python.org/issue17088
+    # Code inspired by https://gist.github.com/provegard/1381912 .
+    if elt.tag[0] == "{":
+        uri, _ = elt.tag[1:].rsplit("}", 1)
+        new_attrib = {}
+        for name, value in elt.attrib.items():
+            if name[0] != "{":
+                # For un-namespaced attributes, copy namespace from element.
+                name = f"{{{uri}}}{name}"
+            new_attrib[name] = value
+        elt.attrib = new_attrib
+    for child in elt:
+        fix_attrib_namespace(child)
+
+
+def main(image_fh, marker_file):
+    """
+    Parameters
+    ---------
+    image_fh : str
+        File path to the OME Tiff image.
+    marker_file : str
+        File path to CSV containing marker name information.
+    """
+
+    # parse marker file, create list of new marker names
+    new_channel_names = []
+    with open(marker_file, newline='') as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            new_channel_names.append(row['marker_name'])
+
+    # read OME-XML metadata and parse down to channels
+    xml_ns = {"ome": "http://www.openmicroscopy.org/Schemas/OME/2016-06"}
+    root = xml.etree.ElementTree.fromstring(tiffcomment(image_fh))
+    image = root.find("ome:Image", xml_ns)
+    pixels = image.find("ome:Pixels", xml_ns)
+    channels = pixels.findall("ome:Channel", xml_ns)
+
+    # name channels
+    for channel, name in zip(channels, new_channel_names):
+        channel.attrib["Name"] = name
+
+    # encode new xml and set image metadata
+    fix_attrib_namespace(root)
+    new_ome_xml = xml.etree.ElementTree.tostring(
+        root, 
+        encoding='utf-8',
+        xml_declaration=True,
+        default_namespace=xml_ns["ome"])
+
+    tiffcomment(image_fh, comment=new_ome_xml)
+
+    print("Updated OME-TIFF metadata:")
+    print(tiffcomment(image_fh))
+
+if __name__ == '__main__':
+    aparser = argparse.ArgumentParser()
+    aparser.add_argument("-i", "--image", dest="image", required=True)
+    aparser.add_argument("-m", "--markers", dest="markers", required=True)
+
+    args = aparser.parse_args()
+
+    main(args.image, args.markers)

--- a/tools/ashlar/rename_channels.py
+++ b/tools/ashlar/rename_channels.py
@@ -3,11 +3,10 @@
 # https://github.com/ohsu-comp-bio/ashlar/blob/master/pyramid_upgrade.py
 # ------------------------------------------------------------------------------------
 
-import os
-import sys 
 import argparse
 import csv
 import xml.etree.ElementTree
+
 from tifffile import tiffcomment
 
 
@@ -61,7 +60,7 @@ def main(image_fh, marker_file):
     # encode new xml and set image metadata
     fix_attrib_namespace(root)
     new_ome_xml = xml.etree.ElementTree.tostring(
-        root, 
+        root,
         encoding='utf-8',
         xml_declaration=True,
         default_namespace=xml_ns["ome"])
@@ -70,6 +69,7 @@ def main(image_fh, marker_file):
 
     print("Updated OME-TIFF metadata:")
     print(tiffcomment(image_fh))
+
 
 if __name__ == '__main__':
     aparser = argparse.ArgumentParser()

--- a/tools/ashlar/test-data/ashlar_test_markers.csv
+++ b/tools/ashlar/test-data/ashlar_test_markers.csv
@@ -1,0 +1,3 @@
+round,channel,marker_name
+0,0,DAPI
+0,1,CD3


### PR DESCRIPTION
Problem described here: https://github.com/goeckslab/tools-mti/issues/62 

This PR is just a wrapper update for the ashlar tool (still at 1.18.0) to restore channel naming functionality that was lost in the last update. 

---

**This PR is related to**
- [ ] Adding a new tool 
- [ ] Updating an existing tool to a newer version
- [x] Fixing a bug or updating just the Galaxy wrapper of an existing tool
- [ ] Making a change to the `tools-mti` repo, CI, or other misc. change

---

### Provide details here

This PR is a quick fix so that we can update the [Galaxy-ME tutorial](https://training.galaxyproject.org/training-material/topics/imaging/tutorials/multiplex-tissue-imaging-TMA/tutorial.html) and maintain contiguity with the steps outlined in the original tutorial. It would be a bummer to remove the channel naming step in this iteration of the tutorial, just for it to come back in future iterations 
