### PR TITLE
more permissive WORKDIR

### DIFF
--- a/tools/vitessce/dependencies/Dockerfile
+++ b/tools/vitessce/dependencies/Dockerfile
@@ -17,9 +17,10 @@ RUN pip install \
     rm -rf /var/lib/apt/lists/* && \
     wget 'https://downloads.openmicroscopy.org/bio-formats/8.1.0/artifacts/bftools.zip' -O bftools.zip && \
     unzip -n -j bftools.zip "bftools/*" -d /usr/local/bin/ && \
-    rm -f bftools.zip
+    rm -f bftools.zip && \
+    mkdir -m 777 /vitessce
 
 USER vitessce
-WORKDIR /home/vitessce
+WORKDIR /vitessce
 
 CMD ['bash']


### PR DESCRIPTION
in the previous version of the tool container the WORKDIR was restricted to the default user, causing issues when the container was run as different users; to fix this, a new WORKDIR with global permissions is now the default so that any user can `rwx`

---

**This PR is related to**
- [ ] Adding a new tool 
- [ ] Updating an existing tool to a newer version
- [X] Fixing a bug or updating just the Galaxy wrapper of an existing tool
- [ ] Making a change to the `tools-mti` repo, CI, or other misc. change

---

### Provide details here
see: https://github.com/galaxyproject/training-material/pull/5810