### PR TITLE
Add Galaxy‐aware URL support  to the Vitessce wrapper

### DIFF
--- a/tools/vitessce/gate_finder.xml
+++ b/tools/vitessce/gate_finder.xml
@@ -16,7 +16,7 @@
             <![CDATA[
             {
             "galaxy_url": "${__app__.config.galaxy_infrastructure_url}",
-            "dataset_id": "${__app__.security.encode_id($image.dataset.id)}"
+            "dataset_id": "${__app__.security.encode_id($output.dataset.id)}"
             }
                     ]]>
         </configfile>

--- a/tools/vitessce/gate_finder.xml
+++ b/tools/vitessce/gate_finder.xml
@@ -12,6 +12,14 @@
     <expand macro="vitessce_cmd" tool_id="gate_finder" />
     <configfiles>
         <inputs name="inputs" />
+        <configfile name="galaxy_config">
+            <![CDATA[
+            {
+            "galaxy_url": "${__app__.config.galaxy_infrastructure_url}",
+            "dataset_id": "${__app__.security.encode_id($image.dataset.id)}"
+            }
+                    ]]>
+        </configfile>
     </configfiles>
     <inputs>
         <param name="image" type="data" format="ome.tiff" label="Select the image (OME-TIFF)" />

--- a/tools/vitessce/index.html
+++ b/tools/vitessce/index.html
@@ -27,31 +27,13 @@
       import { Vitessce } from 'vitessce';
       import { config } from './config.js';
 
-      console.log('here be url: '+window.location.href);
-      var current_url = window.location.href.replace(new RegExp('\/[^\/]*$'), '');
-      console.log(current_url);
-      function rewriteURL(input) {
-        for (let k in input) {
-        if (typeof input[k] === 'string' || input[k] instanceof String) {
-            input[k] = input[k].replace('http://localhost', current_url)
-        }
-        else {
-            input[k] = rewriteURL(input[k])
-        }
-        }
-        return input;
-      };
-      var fixed_conf = {...config};
-      fixed_conf = rewriteURL(fixed_conf);
-      console.log('conf fixed:');
-      console.log(fixed_conf);
       function MyApp() {
         return React.createElement(
           Vitessce,
           {
             height: 1000,
             theme: 'dark',
-            config: fixed_conf,
+            config: config,
           }
         );
       }

--- a/tools/vitessce/main_macros.xml
+++ b/tools/vitessce/main_macros.xml
@@ -68,6 +68,7 @@
             --inputs '$inputs'
             --output '${output.files_path}'
             --image '${output.files_path}/A/0/image01.ome.tiff'
+            --galaxy_config '${galaxy_config}'
             --offsets '$image.metadata.offsets'
             #if $masks
                 --masks '${output.files_path}/A/0/masks01.ome.tiff'

--- a/tools/vitessce/main_macros.xml
+++ b/tools/vitessce/main_macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">3.5.1</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">22.01</token>
 
     <xml name="vitessce_requirements">

--- a/tools/vitessce/main_macros.xml
+++ b/tools/vitessce/main_macros.xml
@@ -77,8 +77,9 @@
             --anndata '$anndata'
             #end if
             &&
-        cp '$__tool_directory__/index.html' '$output';
-        echo "export var config = \$(cat ${output.files_path}/config.json)" >> '${output.files_path}/config.js';
+        cp '$__tool_directory__/index.html' '$output' &&
+        sed -i 's|display?filename=/|display?filename=|g' ${output.files_path}/config.json &&
+        echo "export var config = \$(cat ${output.files_path}/config.json)" >> '${output.files_path}/config.js' &&
         cat '${output.files_path}/config.json' >> '$vitessce_config';
         ]]>
         </command>

--- a/tools/vitessce/vitessce_spatial.py
+++ b/tools/vitessce/vitessce_spatial.py
@@ -2,8 +2,8 @@ import argparse
 import json
 import warnings
 from os.path import isdir, join
+# import urllib.parse
 from pathlib import Path
-import urllib.parse
 
 import scanpy as sc
 from anndata import read_h5ad
@@ -84,7 +84,7 @@ def main(inputs, output, image, offsets=None, anndata=None, masks=None, config_p
 
     # Build the prefix that Vitessce should use
     display_prefix = (f"{galaxy_url}/api/datasets/{dataset_id}/display?filename=")
-    
+
     # if no anndata file, export the config with these minimal components
     if not anndata:
         vc.layout(lc | spatial)

--- a/tools/vitessce/vitessce_spatial.xml
+++ b/tools/vitessce/vitessce_spatial.xml
@@ -16,6 +16,14 @@
 
     <configfiles>
         <inputs name="inputs" />
+        <configfile name="galaxy_config">
+            <![CDATA[
+            {
+            "galaxy_url": "${__app__.config.galaxy_infrastructure_url}",
+            "dataset_id": "${__app__.security.encode_id($image.dataset.id)}"
+            }
+                    ]]>
+        </configfile>
     </configfiles>
 
     <inputs>
@@ -88,7 +96,12 @@
     </inputs>
     <outputs>
         <data format="html" name="output" />
-        <data format="json" name="vitessce_config" from_work_dir="config.json" hidden="true" label="Vitessce config file on ${on_string}" />
+        <data format="json" 
+              name="vitessce_config" 
+              from_work_dir="config.json" 
+              hidden="true" 
+              label="Vitessce config file on ${on_string}">
+        </data>
     </outputs>
     <tests>
         <test>

--- a/tools/vitessce/vitessce_spatial.xml
+++ b/tools/vitessce/vitessce_spatial.xml
@@ -20,7 +20,7 @@
             <![CDATA[
             {
             "galaxy_url": "${__app__.config.galaxy_infrastructure_url}",
-            "dataset_id": "${__app__.security.encode_id($image.dataset.id)}"
+            "dataset_id": "${__app__.security.encode_id($output.dataset.id)}"
             }
                     ]]>
         </configfile>


### PR DESCRIPTION
### Add Galaxy‐aware URL support to the Vitessce wrapper. 

---

**This PR is related to**
- [ x] Updating an existing tool 
---

**If updating an existing tool **
- [x ] I have updated the Version Suffix

---

### Provide details here

- Cite relevant [issues](https://github.com/orgs/galaxyproject/projects/63/views/2?pane=issue&itemId=103696587)

**This PR makes the following enhancements to the Vitessce Galaxy tools:**

- Acquire Galaxy URL and Dataset Id in the configuration section in configfiles.

- Added galaxy_config to both vitessce_spatial.py and gate_finder.py and replaced hard-coded http://localhost with the injected value after unpacking it.

- Updated main_macros.xml to accept --galaxy_config.

