### PR TITLE
Fix url buidling for vitessce dashboard

### DIFF
--- a/tools/vitessce/gate_finder.xml
+++ b/tools/vitessce/gate_finder.xml
@@ -16,7 +16,7 @@
             <![CDATA[
             {
             "galaxy_url": "${__app__.config.galaxy_infrastructure_url}",
-            "dataset_id": "${__app__.security.encode_id($output.dataset.id)}"
+            "dataset_id": "${__app__.security.encode_id($output.id)}"
             }
                     ]]>
         </configfile>

--- a/tools/vitessce/main_macros.xml
+++ b/tools/vitessce/main_macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">3.5.1</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <token name="@PROFILE@">22.01</token>
 
     <xml name="vitessce_requirements">

--- a/tools/vitessce/vitessce_spatial.xml
+++ b/tools/vitessce/vitessce_spatial.xml
@@ -20,7 +20,7 @@
             <![CDATA[
             {
             "galaxy_url": "${__app__.config.galaxy_infrastructure_url}",
-            "dataset_id": "${__app__.security.encode_id($output.dataset.id)}"
+            "dataset_id": "${__app__.security.encode_id($output.id)}"
             }
                     ]]>
         </configfile>


### PR DESCRIPTION
`dataset.id` is the id of the dataset, what we want is the history dataset association id. On a clean new instance (as planemo gives you) this probably works, but once you starting copying HDAs or collections the dataset_id will be lower, most likely pointing at some random old history dataset association you likely won't have access to.

draft while I make sure this works

### Please replace this header with a short description of your pull request. Please include BOTH what you did and why you made the changes

---

**This PR is related to**
- [ ] Adding a new tool 
- [ ] Updating an existing tool to a newer version
- [x] Fixing a bug or updating just the Galaxy wrapper of an existing tool
- [ ] Making a change to the `tools-mti` repo, CI, or other misc. change

---

**If updating an existing tool to a newer major version**
- [ ] I have updated the `TOOL_VERSION` token in the tool's macros file 
- [ ] I have reset the `VERSION_SUFFIX` to `0` in the tool's macros file 

---

### Provide details here

- Cite relevant [issues](https://github.com/goeckslab/tools-mti/issues) if applicable
- If fixing a bug, please add any relevant error or traceback
- If adding or updating tools, please describe how tool requirements are satisfied (Examples: "Created new Docker container for scimap", "Added scimap to Bioconda", etc.)