### PR TITLE
Add element_identifier handling in scimap_mcmicro_to_anndata

### DIFF
--- a/tools/scimap/main_macros.xml
+++ b/tools/scimap/main_macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.1.0</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@VERSION_SUFFIX@">3</token>
     <token name="@PROFILE@">20.01</token>
 
     <xml name="scimap_requirements">

--- a/tools/scimap/mcmicro_to_anndata.py
+++ b/tools/scimap/mcmicro_to_anndata.py
@@ -20,13 +20,15 @@ def main(inputs, outfile):
     with open(inputs, 'r') as param_handler:
         params = json.load(param_handler)
 
-    image_path = params['image_path']
+    image_path = params['image_path']['source_path']
     drop_markers = params['drop_markers']
     if not drop_markers:
         drop_markers = None
     else:
         drop_markers = [x.strip() for x in drop_markers.split(',')]
     options = params['options']
+    if not options.get('custom_imageid'):
+        options['custom_imageid'] = params['image_path']['element_identifier']
     for k, v in options.items():
         if v == '':
             options[k] = None

--- a/tools/scimap/mcmicro_to_anndata.py
+++ b/tools/scimap/mcmicro_to_anndata.py
@@ -28,7 +28,9 @@ def main(inputs, outfile):
         drop_markers = [x.strip() for x in drop_markers.split(',')]
     options = params['options']
     if not options.get('custom_imageid'):
-        options['custom_imageid'] = params['image_path']['element_identifier']
+        element_identifier = params['image_path']['element_identifier']
+        # Might be a list on unpatched versions of Galaxy, xref: https://github.com/galaxyproject/galaxy/pull/20438
+        options['custom_imageid'] = element_identifier if isinstance(element_identifier, str) else element_identifier[0]
     for k, v in options.items():
         if v == '':
             options[k] = None

--- a/tools/scimap/mcmicro_to_anndata.xml
+++ b/tools/scimap/mcmicro_to_anndata.xml
@@ -15,7 +15,7 @@
         ]]>
     </command>
     <configfiles>
-        <inputs name="inputs" data_style="paths"/>
+        <inputs name="inputs" data_style="staging_path_and_source_path"/>
     </configfiles>
     <inputs>
         <param argument="image_path" type="data" format="tabular,csv" multiple="false" label="Select the input image or images" />


### PR DESCRIPTION
This uses the history name (either the dataset name or the element identifier if the dataset is in a collection) if no explicit image id is given.

**This PR is related to**
- [ ] Adding a new tool 
- [ ] Updating an existing tool to a newer version
- [x] Fixing a bug or updating just the Galaxy wrapper of an existing tool
- [ ] Making a change to the `tools-mti` repo, CI, or other misc. change

---

**If updating an existing tool to a newer major version**
- [ ] I have updated the `TOOL_VERSION` token in the tool's macros file 
- [ ] I have reset the `VERSION_SUFFIX` to `0` in the tool's macros file 

---

### Provide details here

- Cite relevant [issues](https://github.com/goeckslab/tools-mti/issues) if applicable
- If fixing a bug, please add any relevant error or traceback
- If adding or updating tools, please describe how tool requirements are satisfied (Examples: "Created new Docker container for scimap", "Added scimap to Bioconda", etc.)