### PR TITLE
Target new API endpoint `/extra_files/raw`

### DIFF
--- a/tools/vitessce/main_macros.xml
+++ b/tools/vitessce/main_macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <token name="@TOOL_VERSION@">3.5.1</token>
     <token name="@VERSION_SUFFIX@">3</token>
-    <token name="@PROFILE@">22.01</token>
+    <token name="@PROFILE@">25.0</token>
 
     <xml name="vitessce_requirements">
         <requirements>

--- a/tools/vitessce/main_macros.xml
+++ b/tools/vitessce/main_macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">3.5.1</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@VERSION_SUFFIX@">3</token>
     <token name="@PROFILE@">22.01</token>
 
     <xml name="vitessce_requirements">
@@ -78,7 +78,6 @@
             #end if
             &&
         cp '$__tool_directory__/index.html' '$output' &&
-        sed -i 's|display?filename=/|display?filename=|g' ${output.files_path}/config.json &&
         echo "export var config = \$(cat ${output.files_path}/config.json)" >> '${output.files_path}/config.js' &&
         cat '${output.files_path}/config.json' >> '$vitessce_config';
         ]]>

--- a/tools/vitessce/vitessce_spatial.py
+++ b/tools/vitessce/vitessce_spatial.py
@@ -83,7 +83,7 @@ def main(inputs, output, image, offsets=None, anndata=None, masks=None, config_p
         h=lc_dims[1])
 
     # Build the prefix that Vitessce should use
-    display_prefix = (f"{galaxy_url}/api/datasets/{dataset_id}/display?filename=")
+    display_prefix = f"{galaxy_url}/api/datasets/{dataset_id}/extra_files/raw"
 
     # if no anndata file, export the config with these minimal components
     if not anndata:


### PR DESCRIPTION
As the vitessce webclient will append relative paths to the base url

Fixes empty panels that make use of anndata files:

![image](https://github.com/user-attachments/assets/5c191a0e-ac80-4946-a50b-3584d061d719)

This is because vitessce frontend will build urls like https://usegalaxy.org/api/datasets/f9cad7b01a4721358531a44ecfb1aff6/display/obs/.zattrs?filename=A/1/bdbd683b-1870-4c11-ae29-b35ff0be59b2.adata.zarr where we would (previously) need https://usegalaxy.org/api/datasets/f9cad7b01a4721358531a44ecfb1aff6/display?filename=A/1/bdbd683b-1870-4c11-ae29-b35ff0be59b2.adata.zarr/obs/.zattrs

I've added another endpoint at `api/datasets/{dataset_id}/extra_files/raw/{path}`, so that the vitessce frontend logic will work correctly.

### Please replace this header with a short description of your pull request. Please include BOTH what you did and why you made the changes

---

**This PR is related to**
- [ ] Adding a new tool 
- [ ] Updating an existing tool to a newer version
- [ ] Fixing a bug or updating just the Galaxy wrapper of an existing tool
- [ ] Making a change to the `tools-mti` repo, CI, or other misc. change

---

**If updating an existing tool to a newer major version**
- [ ] I have updated the `TOOL_VERSION` token in the tool's macros file 
- [ ] I have reset the `VERSION_SUFFIX` to `0` in the tool's macros file 

---

### Provide details here

- Cite relevant [issues](https://github.com/goeckslab/tools-mti/issues) if applicable
- If fixing a bug, please add any relevant error or traceback
- If adding or updating tools, please describe how tool requirements are satisfied (Examples: "Created new Docker container for scimap", "Added scimap to Bioconda", etc.)